### PR TITLE
P2P Children now save with Select set to Multiple

### DIFF
--- a/rbm-cpts.php
+++ b/rbm-cpts.php
@@ -6,7 +6,7 @@
  * Author: Real Big Marketing
  * Author URI: http://realbigmarketing.com
  * GitHub Plugin URI: realbig/rbm-cpts
- * GitHub Branch: develop
+ * GitHub Branch: issue/11/saving-p2p-with-multiple-select
  */
 
 defined( 'ABSPATH' ) || die();


### PR DESCRIPTION
See #11 

Now Save/Delete assumes the Post Meta is an Array and if it isn't, wraps it in an Array. This should provide backwards compatibility in a graceful fashion.

There appear to be lots of changes, but it is mostly indenting a level further after wrapping in a `foreach` ¯\\_(ツ)\_/¯